### PR TITLE
Removeflag

### DIFF
--- a/solc/main.py
+++ b/solc/main.py
@@ -119,9 +119,11 @@ def compile_files(source_files, output_values=None, **kwargs):
         raise ValueError(
             "The `combined_json` keyword is not allowed in the `compile_files` function")
     ol = ALL_OUTPUT_VALUES
-    if 'removeflag' in kwargs and kwargs['removeflag'] is not None:
-        ol.remove(kwargs['removeflag'])
-    kwargs.pop('removeflag')
+    if 'removeflag' in kwargs:
+        if kwargs['removeflag'] is not None:
+            ol.remove(kwargs['removeflag'])
+        kwargs.pop('removeflag')
+    
     output_values = ol
     combined_json = ','.join(output_values)
 

--- a/solc/main.py
+++ b/solc/main.py
@@ -123,7 +123,6 @@ def compile_files(source_files, output_values=None, **kwargs):
         if kwargs['removeflag'] is not None:
             ol.remove(kwargs['removeflag'])
         kwargs.pop('removeflag')
-    
     output_values = ol
     combined_json = ','.join(output_values)
 

--- a/solc/main.py
+++ b/solc/main.py
@@ -110,7 +110,7 @@ def compile_source(source, output_values=ALL_OUTPUT_VALUES, **kwargs):
     return contracts
 
 
-def compile_files(source_files, output_values=ALL_OUTPUT_VALUES, **kwargs):
+def compile_files(source_files, output_values=None, **kwargs):
     if 'source_files' in kwargs:
         raise ValueError(
             "The `source_files` keyword is not allowed in the `compile_files` function"
@@ -119,6 +119,16 @@ def compile_files(source_files, output_values=ALL_OUTPUT_VALUES, **kwargs):
         raise ValueError(
             "The `combined_json` keyword is not allowed in the `compile_files` function"
         )
+    ol = ALL_OUTPUT_VALUES
+
+    if 'removeflag'  in kwargs:
+        print('ere')
+        ol.remove(kwargs['removeflag'])
+        output_values = ol
+        kwargs.pop('removeflag')
+    else:
+        print('toto')
+        output_values = ol
 
     combined_json = ','.join(output_values)
 

--- a/solc/main.py
+++ b/solc/main.py
@@ -119,9 +119,9 @@ def compile_files(source_files, output_values=None, **kwargs):
         raise ValueError(
             "The `combined_json` keyword is not allowed in the `compile_files` function")
     ol = ALL_OUTPUT_VALUES
-    if 'removeflag' in kwargs:
+    if 'removeflag' in kwargs and kwargs['removeflag'] is not None:
         ol.remove(kwargs['removeflag'])
-        kwargs.pop('removeflag')
+    kwargs.pop('removeflag')
     output_values = ol
     combined_json = ','.join(output_values)
 

--- a/solc/main.py
+++ b/solc/main.py
@@ -117,19 +117,12 @@ def compile_files(source_files, output_values=None, **kwargs):
         )
     if 'combined_json' in kwargs:
         raise ValueError(
-            "The `combined_json` keyword is not allowed in the `compile_files` function"
-        )
+            "The `combined_json` keyword is not allowed in the `compile_files` function")
     ol = ALL_OUTPUT_VALUES
-
-    if 'removeflag'  in kwargs:
-        print('ere')
+    if 'removeflag' in kwargs:
         ol.remove(kwargs['removeflag'])
-        output_values = ol
         kwargs.pop('removeflag')
-    else:
-        print('toto')
-        output_values = ol
-
+    output_values = ol
     combined_json = ','.join(output_values)
 
     stdoutdata, stderrdata = solc_wrapper(


### PR DESCRIPTION
### What was wrong?
`output_values` defaults to `ALL_OUTPUT_VALUES` in , wanted to be able to remove certain flags from that list

### How was it fixed?
Now it defaults to None and is set to ALL_OUTPUT_VALUES in case `removeflag` doesnt exist in kwargs, if removeflag exists it passes the same list minus the removeflag 


#### Cute Animal Picture

> put a cute animal picture here.
