### PR TITLE
Switched to semantic_version for versioning

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import semantic_version
 
 
 @pytest.fixture()
@@ -8,12 +9,4 @@ def contracts_dir(tmpdir):
 
 @pytest.fixture(scope="session")
 def SUPPORTED_SOLC_VERSIONS():
-    return {
-        "0.4.1",
-        "0.4.2",
-        "0.4.4",
-        "0.4.6",
-        "0.4.7",
-        "0.4.8",
-        "0.4.9",
-    }
+    return semantic_version.Spec('>=0.4.1,<=0.4.11')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest>=2.9.2
 tox>=2.3.1
+semantic_version

--- a/solc/main.py
+++ b/solc/main.py
@@ -17,6 +17,7 @@ from .wrapper import (
     solc_wrapper,
 )
 
+import semantic_version
 
 version_regex = re.compile('([0-9]+\.[0-9]+\.[0-9]+)')
 
@@ -40,14 +41,10 @@ def get_solc_version_string(**kwargs):
 
 
 def get_solc_version(**kwargs):
-    version_string = get_solc_version_string(**kwargs)
-
-    version_match = version_regex.search(version_string)
-    if version_match is None:
-        raise ValueError(
-            "Unable to find version in version string: {0}".format(version_string)
-        )
-    return version_match.group()
+    # semantic_version as of 2017-5-5 expects only one + to be used in string
+    return semantic_version.Version(get_solc_version_string(**kwargs)
+        [len('Version: '):]
+        .replace('++', 'pp'))
 
 
 def _parse_compiler_output(stdoutdata):

--- a/solc/main.py
+++ b/solc/main.py
@@ -20,6 +20,9 @@ from .wrapper import (
 import semantic_version
 
 
+VERSION_DEV_DATE_MANGLER_RE = re.compile(r'(\d{4})\.0?(\d{1,2})\.0?(\d{1,2})')
+strip_zeroes_from_month_and_day = functools.partial(VERSION_DEV_DATE_MANGLER_RE.sub,
+                                                    r'\g<1>.\g<2>.\g<3>')
 is_solc_available = functools.partial(is_executable_available, SOLC_BINARY)
 
 
@@ -40,9 +43,11 @@ def get_solc_version_string(**kwargs):
 
 def get_solc_version(**kwargs):
     # semantic_version as of 2017-5-5 expects only one + to be used in string
-    return semantic_version.Version(get_solc_version_string(**kwargs)
-        [len('Version: '):]
-        .replace('++', 'pp'))
+    return semantic_version.Version(
+        strip_zeroes_from_month_and_day(
+            get_solc_version_string(**kwargs)
+            [len('Version: '):]
+            .replace('++', 'pp')))
 
 
 def _parse_compiler_output(stdoutdata):

--- a/solc/main.py
+++ b/solc/main.py
@@ -19,8 +19,6 @@ from .wrapper import (
 
 import semantic_version
 
-version_regex = re.compile('([0-9]+\.[0-9]+\.[0-9]+)')
-
 
 is_solc_available = functools.partial(is_executable_available, SOLC_BINARY)
 

--- a/tests/compilation/test_compile_from_source_code.py
+++ b/tests/compilation/test_compile_from_source_code.py
@@ -1,3 +1,4 @@
+from semantic_version import Spec
 from solc import (
     get_solc_version,
     get_solc_version_string,
@@ -19,7 +20,7 @@ def test_source_code_compilation(SUPPORTED_SOLC_VERSIONS):
     output = compile_source(SOURCE, optimize=True)
     assert output
 
-    if solc_version == '0.4.9':
+    if solc_version in Spec('>=0.4.9'):
         contact_key = '<stdin>:Foo'
     else:
         contact_key = 'Foo'

--- a/tests/compilation/test_compiler_from_source_file.py
+++ b/tests/compilation/test_compiler_from_source_file.py
@@ -1,5 +1,6 @@
 import os
 
+from semantic_version import Spec
 from solc import (
     get_solc_version,
     get_solc_version_string,
@@ -8,6 +9,7 @@ from solc import (
 
 
 def test_source_files_compilation(contracts_dir, SUPPORTED_SOLC_VERSIONS):
+    import pdb; pdb.set_trace()
     solc_version_string = get_solc_version_string()
 
     solc_version = get_solc_version()
@@ -25,7 +27,7 @@ def test_source_files_compilation(contracts_dir, SUPPORTED_SOLC_VERSIONS):
 
     assert output
 
-    if solc_version == '0.4.9':
+    if solc_version in Spec('>=0.4.9'):
         contact_key = '{0}:Foo'.format(os.path.abspath(source_file_path))
     else:
         contact_key = 'Foo'

--- a/tests/compilation/test_compiler_from_source_file.py
+++ b/tests/compilation/test_compiler_from_source_file.py
@@ -9,7 +9,6 @@ from solc import (
 
 
 def test_source_files_compilation(contracts_dir, SUPPORTED_SOLC_VERSIONS):
-    import pdb; pdb.set_trace()
     solc_version_string = get_solc_version_string()
 
     solc_version = get_solc_version()

--- a/tests/compilation/test_compiler_remappings.py
+++ b/tests/compilation/test_compiler_remappings.py
@@ -1,5 +1,6 @@
 import os
 
+from semantic_version import Spec
 from solc import (
     get_solc_version,
     compile_files,
@@ -27,7 +28,7 @@ def test_import_remapping(contracts_dir):
 
     assert output
 
-    if solc_version == '0.4.9':
+    if solc_version in Spec('>=0.4.9'):
         contact_key = '{0}:Foo'.format(os.path.abspath(source_file_path))
     else:
         contact_key = 'Foo'

--- a/tests/utility/test_solc_version.py
+++ b/tests/utility/test_solc_version.py
@@ -2,14 +2,10 @@ import re
 
 from solc import get_solc_version
 
+import semantic_version
+
 
 def test_get_solc_version():
     version = get_solc_version()
 
-    assert version
-
-    major, minor, patch = version.split('.')
-
-    assert major.isdigit()
-    assert minor.isdigit()
-    assert patch.isdigit()
+    assert isinstance(version, semantic_version.Version)

--- a/tests/wrapper/test_solc_wrapper.py
+++ b/tests/wrapper/test_solc_wrapper.py
@@ -34,21 +34,21 @@ def test_help():
     output, err, _, _ = solc_wrapper(help=True, success_return_code=1)
     assert output
     assert 'Solidity' in output
-    assert not err
+    assert not err or err == 'Warning: This is a pre-release compiler version, please do not use it in production.\n'
 
 
 def test_version():
     output, err, _, _ = solc_wrapper(version=True)
     assert output
     assert 'Version' in output
-    assert not err
+    assert not err or err == 'Warning: This is a pre-release compiler version, please do not use it in production.\n'
 
 
 def test_providing_stdin(FOO_SOURCE):
     output, err, _, _ = solc_wrapper(stdin_bytes=FOO_SOURCE, bin=True)
     assert output
     assert 'Foo' in output
-    assert not err
+    assert not err or err == 'Warning: This is a pre-release compiler version, please do not use it in production.\n'
 
 
 def test_providing_single_source_file(contracts_dir, FOO_SOURCE):
@@ -59,7 +59,7 @@ def test_providing_single_source_file(contracts_dir, FOO_SOURCE):
     output, err, _, _ = solc_wrapper(source_files=[source_file_path], bin=True)
     assert output
     assert 'Foo' in output
-    assert not err
+    assert not err or err == 'Warning: This is a pre-release compiler version, please do not use it in production.\n'
 
 
 def test_providing_multiple_source_files(contracts_dir, FOO_SOURCE, BAR_SOURCE):
@@ -75,4 +75,4 @@ def test_providing_multiple_source_files(contracts_dir, FOO_SOURCE, BAR_SOURCE):
     assert output
     assert 'Foo' in output
     assert 'Bar' in output
-    assert not err
+    assert not err or err == 'Warning: This is a pre-release compiler version, please do not use it in production.\n'


### PR DESCRIPTION
### What was wrong?

When I ran the tests, the tests would fail because the version check is too specific. Also, some information about the solc version was not captured.

### How was it fixed?

I switched it to use `semantic_version`. I had to replace `++` with `pp` from the version string because that library doesn't like having more than one `+` in the string. I may address that soon, but for now, this is fine. Also, having a `solc` that is not an official release also passes the tests. I feel this is fine since the tests are mainly for developers anyway.

#### Cute Animal Picture

> ![They will scratch your face off](https://media.giphy.com/media/Hrr0GblXsiE7u/giphy.gif)