### PR TITLE
Pin semantic-version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 pytest>=2.9.2
 tox>=2.3.1
-semantic_version
+semantic_version>=2.6.0


### PR DESCRIPTION
### What was wrong?

I didn't pin `semantic-version`

### How was it fixed?

I pinned `semantic-version` to the 2.6.0 series

#### Cute Animal Picture

> ![Frogger](http://3.bp.blogspot.com/-1I-LqHL01NM/TaPGkj7DlTI/AAAAAAAAHCg/-rT96aUz238/s1600/cute-animals-wallpaper.jpg).
