### PR TITLE
refactor how support for standard json is calculated

### DIFF
--- a/solc/main.py
+++ b/solc/main.py
@@ -56,12 +56,7 @@ def get_solc_version(**kwargs):
 
 
 def solc_supports_standard_json_interface(**kwargs):
-    kwargs['help'] = True
-    # HACK: account for solc return code being 1 when it should be 0
-    zero_or_one = type('retcodehack', (tuple,), {'__ne__': lambda s, x: x not in s})((0, 1))
-    kwargs['success_return_code'] = zero_or_one
-    stdoutdata, _, _, _ = solc_wrapper(**kwargs)
-    return '--standard-json' in stdoutdata
+    return get_solc_version() in semantic_version.Spec('>=0.4.11')
 
 
 def _parse_compiler_output(stdoutdata):


### PR DESCRIPTION
### What was wrong?

The way that support for standard json compilation was queried was not idea, parsing the text output from `solc --help`.

### How was it fixed?

Changed it so leverage the existing `get_solc_version` and do a simple comparison that it is at least `>=0.4.11` which is when the standard json compilation was introduced.

#### Cute Animal Picture

> put a cute animal picture here.

![cutest_baby](https://user-images.githubusercontent.com/824194/28339536-9f7a514e-6bc9-11e7-9d3a-bc0460ce35d8.jpg)
