### PR TITLE
using get_platform() function instead of sys.platform

### DIFF
--- a/scripts/install_solc.py
+++ b/scripts/install_solc.py
@@ -359,4 +359,4 @@ if __name__ == "__main__":
         print("Invocation error.  Should be invoked as `./install_solc.py <version>`")
         sys.exit(1)
 
-    install_solc(sys.platform, identifier)
+    install_solc(get_platform(), identifier)

--- a/solc/install.py
+++ b/solc/install.py
@@ -431,7 +431,7 @@ INSTALL_FUNCTIONS = {
 
 def install_solc(identifier, platform=None):
     if platform is None:
-        platform = sys.platform
+        platform = get_platform()
 
     if platform not in INSTALL_FUNCTIONS:
         raise ValueError(


### PR DESCRIPTION
# What was wrong?

get_platform() function was not being used. Because of this, some linux platforms were unable to use py-solc. See issue #32

# How was it fixed?

I replaced areas of the code where "sys.platform" was being used with the get_platform() function.

 

This is my first ever pull-request... Please be nice! Hah. 

Feedback appreciated